### PR TITLE
Disable production CSS sourcemap as it can't be extracted for some reason

### DIFF
--- a/build/vue-loader.conf.js
+++ b/build/vue-loader.conf.js
@@ -5,8 +5,10 @@ var isProduction = process.env.NODE_ENV === 'production'
 module.exports = {
   loaders: utils.cssLoaders({
     sourceMap: isProduction
-      ? config.build.productionSourceMap
-      : config.dev.cssSourceMap,
+    // not 'config.build.productionSourceMap', as we're loading CSS in via injecting <styles/>.
+    // Do not include CSS sourcemap to save *a lot* of space as it can't be separate out for some reason.
+    ? false
+    : config.dev.cssSourceMap,
     extract: false
   }),
   esModule: true,


### PR DESCRIPTION
Cuts the size of the bundled JS+CSS by HALF.
